### PR TITLE
Add water sensor support.

### DIFF
--- a/lib/device.js
+++ b/lib/device.js
@@ -182,21 +182,21 @@ Device.prototype.getCharacteristicValues = function() {
                         [Characteristic.CurrentRelativeHumidity.UUID]: (reported.humidity || {}).percent,
                     };
                     break;
-                case Service.SmokeSensor:
-                    if (undefined !== trigger.state) {
-                        characteristics = {
-                            [Characteristic.SmokeDetected.UUID]: 'ok' == trigger.state.smoke
-                                    ? Characteristic.SmokeDetected.SMOKE_NOT_DETECTED
-                                    : Characteristic.SmokeDetected.SMOKE_DETECTED,
-                        };
-                    }
-                    break;
                 case Service.LeakSensor:
                     if (undefined !== trigger.state) {
                         characteristics = {
                             [Characteristic.LeakDetected.UUID]: 'dry' == trigger.state
                                     ? Characteristic.LeakDetected.LEAK_NOT_DETECTED
                                     : Characteristic.LeakDetected.LEAK_DETECTED,
+                        };
+                    }
+                    break;
+                case Service.SmokeSensor:
+                    if (undefined !== trigger.state) {
+                        characteristics = {
+                            [Characteristic.SmokeDetected.UUID]: 'ok' == trigger.state.smoke
+                                    ? Characteristic.SmokeDetected.SMOKE_NOT_DETECTED
+                                    : Characteristic.SmokeDetected.SMOKE_DETECTED,
                         };
                     }
                     break;

--- a/lib/device.js
+++ b/lib/device.js
@@ -62,9 +62,6 @@ function Device(homebridge, logger, device) {
             case Service.MotionSensor:
                 characteristics.push(Characteristic.MotionDetected);
                 break;
-            case Service.SmokeSensor:
-                characteristics.push(Characteristic.SmokeDetected);
-                break;
             case Service.TemperatureSensor:
                 characteristics.push(Characteristic.CurrentTemperature);
                 break;
@@ -73,6 +70,9 @@ function Device(homebridge, logger, device) {
                 break;
             case Service.LeakSensor:
                 characteristics.push(Characteristic.LeakDetected);
+                break;
+            case Service.SmokeSensor:
+                characteristics.push(Characteristic.SmokeDetected);
                 break;
         }
 

--- a/lib/device.js
+++ b/lib/device.js
@@ -86,6 +86,7 @@ Device.prototype.getCategory = function(deviceType) {
     switch (deviceType) {
         case 'door_panel':
         case 'access_sensor':
+        case 'water_sensor':
         case 'smoke_alarm':
             return Categories.SENSOR;
         default:

--- a/lib/device.js
+++ b/lib/device.js
@@ -11,6 +11,9 @@ function Device(homebridge, logger, device) {
             Service.ContactSensor,
             Service.TemperatureSensor,
         ],
+        water_sensor: [
+            Service.LeakSensor,
+        ],
         smoke_alarm: [
             Service.SmokeSensor,
             // Temperature is currently buggy // Service.TemperatureSensor,
@@ -61,6 +64,9 @@ function Device(homebridge, logger, device) {
                 break;
             case Service.HumiditySensor:
                 characteristics.push(Characteristic.CurrentRelativeHumidity);
+                break;
+            case Service.LeakSensor:
+                characteristics.push(Characteristic.LeakDetected);
                 break;
         }
 
@@ -160,6 +166,13 @@ Device.prototype.getCharacteristicValues = function() {
                         [Characteristic.SmokeDetected.UUID]: 'ok' == device.reported.trigger.state.smoke
                                 ? Characteristic.SmokeDetected.SMOKE_NOT_DETECTED
                                 : Characteristic.SmokeDetected.SMOKE_DETECTED,
+                    };
+                    break;
+                case Service.LeakSensor:
+                    characteristics = {
+                        [Characteristic.LeakDetected.UUID]: 'dry' == device.reported.trigger.state
+                                ? Characteristic.LeakDetected.LEAK_NOT_DETECTED
+                                : Characteristic.LeakDetected.LEAK_DETECTED,
                     };
                     break;
             }


### PR DESCRIPTION
Addresses #6. These changes are based solely on inspecting the Scout dashboard JavaScript code. I'd rather not merge until I can test with an actual water sensor device.